### PR TITLE
chore: add explicit typeRoots

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,12 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "target": "ESNext",
-    "typeRoots": ["./node_modules/@types", "@types"],
+    "typeRoots": [
+      "./node_modules/@types",
+      "./node_modules/@microsoft",
+      "./node_modules"
+    ],
+    "types": ["vitest/globals"]
   },
   "include": ["./**/*.ts"],
   "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/#explicit-typeroots-disables-upward-walks-for-node_modules-types